### PR TITLE
install docker in build container to avoid image pull issue

### DIFF
--- a/custom-notebook-builder-container/podman/Containerfile
+++ b/custom-notebook-builder-container/podman/Containerfile
@@ -74,6 +74,11 @@ RUN mkdir -p /home/podman/.local/share/containers && \
     chown podman:podman -R /home/podman && \
     chmod 644 /etc/containers/containers.conf
 
+#install docker
+RUN dnf -y install docker && \
+    dnf clean all && \
+    rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+
 # Copy & modify the defaults to provide reference if runtime changes needed.
 # Changes here are required for running with fuse-overlay storage inside container.
 RUN sed -e 's|^#mount_program|mount_program|g' \


### PR DESCRIPTION
Install docker to be able to pull images in the build container. This resolves the error:
`Error: writing blob: adding layer with blob "sha256:de21b519acd77702462adda3568d44cf5b62dadfc75368c1c079936710e3410a"/""/"sha256:4c0b0f646c881b1b8bc0375ca299f082df2580560db3fc78d8bfe5d648d19659": unpacking failed (error: exit status 125; output: Error: unrecognized command `podman /`
`

Reference chat - https://redhat-internal.slack.com/archives/C08PA42J4G4/p1746807616527279

Building image in arm64 vs amd 64 makes a difference. 

![image (10)](https://github.com/user-attachments/assets/2691a74e-3b5f-44b5-afd9-7901ff3b85a2)


